### PR TITLE
Created dashboard and added multi-event creation functionality

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -1,0 +1,7 @@
+.subheader {
+  font-size: 24px;
+  padding-left: 10vw
+}
+.section {
+  margin: 20px 0px;
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,3 +1,4 @@
 // Import page-specific CSS files here.
 @import "home";
 @import "mobfriends";
+@import "dashboard";

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,7 @@ class EventsController < ApplicationController
   def show
     authorize @event
     @date = format_datetime(@event.datetime)
+    @total_cost = total_jobs_cost(@event.jobs)
   end
 
   # form only
@@ -77,5 +78,13 @@ class EventsController < ApplicationController
       suffix = 'PM'
     end
     "#{date}, #{hour}:#{min} #{suffix}"
+  end
+
+  def total_jobs_cost(jobs)
+    total_cost = 0
+    jobs.each do |job|
+      total_cost += job.mobfriend.hourly_rate
+    end
+    return total_cost
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,6 +1,6 @@
 class JobsController < ApplicationController
   def create
-    @event = current_user.events.first
+    @event = Event.find(params[:job][:event])
     @mobfriend = Mobfriend.find(params[:mobfriend_id])
     @job = Job.new(mobfriend: @mobfriend, event: @event)
     authorize @job

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,4 +2,35 @@ class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: [:home]
   def home
   end
+
+  def dashboard
+    # authorize current_user
+    @events = current_user.events
+    @mobfriend = current_user.mobfriend
+    @jobs = current_user.mobfriend.jobs if current_user.mobfriend.present?
+    @pending_events = pending_events
+    @confirmed_events = confirmed_events
+  end
+
+  def your_events
+    # authorize current_user
+    @job = Job.new
+    @mobfriend = Mobfriend.find(params[:mobfriend_id])
+    @events = current_user.events
+    @pending_events = pending_events
+  end
+
+  private
+
+  def pending_events
+    current_user.events.select do |event|
+      event.confirmed == false
+    end
+  end
+
+  def confirmed_events
+    current_user.events.select do |event|
+      event.confirmed
+    end
+  end
 end

--- a/app/views/events/create.html.erb
+++ b/app/views/events/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Events#create</h1>
-<p>Find me in app/views/events/create.html.erb</p>

--- a/app/views/events/destroy.html.erb
+++ b/app/views/events/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Events#destroy</h1>
-<p>Find me in app/views/events/destroy.html.erb</p>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,3 +1,2 @@
-<%= render 'shared/navbar' %>
 <h1>Edit event</h1>
 <%= render 'form' %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/navbar' %>
 <div class="container">
   <h1 class='text-center my-5'>Event Index</h1>
   <% @events.each do |e| %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,3 +1,2 @@
-<%= render 'shared/navbar' %>
 <h1>Create a new event</h1>
 <%= render 'form' %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/navbar' %>
 <div class="header">
   <h1>Current Booking</h1>
 </div>
@@ -10,10 +9,11 @@
     </div>
     <div class="col-lg-8 my-5">
       <ul>
-        <!-- <li>Event ID: <%= @event.id  %></li> -->
         <li>Description: <%= @event.description %></li>
-        <!-- <li>Event User ID: <%= @event.user_id %></li> -->
+        <li>Type: <%= @event.event_type %></li>
         <li>Time: <%= @date %></li>
+        <li>Location: <%= @event.event_location %></li>
+        <li>Total cost: $<%= @total_cost %>/hr</li>
         <% if @event.confirmed %>
           <li>Status: Confirmed</li>
         <% else %>
@@ -37,6 +37,7 @@
     <% end %>
   </div>
   <h2>Your Mobfriends</h2>
+  <h3>who will be meeting you at <%= @event.meeting_location %></h3>
   <div class="row">
     <div class="mobfriends-avatar-container container">
       <div class="row">
@@ -52,8 +53,10 @@
               <% end %>
             </div>
             <p><%= job.mobfriend.first_name %></p>
-            <div class="btn btn-info"><%= link_to 'View', mobfriend_path(job.mobfriend) %></div>
-            <div class="btn btn-danger"><%= link_to 'Delete', job_path(job), method: :delete %></div>
+            <div class="mobfriend-buttons">
+              <div class="btn btn-info"><%= link_to 'View', mobfriend_path(job.mobfriend) %></div>
+              <div class="btn btn-danger"><%= link_to 'Delete', job_path(job), method: :delete %></div>
+            </div>
           </div>
         <% end %>
       </div>

--- a/app/views/events/update.html.erb
+++ b/app/views/events/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Events#update</h1>
-<p>Find me in app/views/events/update.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   <body>
 
     <%= javascript_include_tag 'application' %>
+    <%= render 'shared/navbar' %>
     <%= yield %>
     <%= javascript_pack_tag 'application' %>
   </body>

--- a/app/views/mobfriends/edit.html.erb
+++ b/app/views/mobfriends/edit.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/navbar' %>
 <div class="page-header">
   <h1>Edit Profile</h1>
 </div>

--- a/app/views/mobfriends/index.html.erb
+++ b/app/views/mobfriends/index.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/navbar' %>
 <h1 class='text-center my-5'>Select a Mobfriend</h1>
 <div class="mobfriends-container container">
   <div class="row">
@@ -31,9 +30,7 @@
           <div class="btn btn-info">
             <%= link_to 'View', mobfriend_path(mobfriend) %>
           </div>
-          <%= simple_form_for [mobfriend, @job] do |f| %>
-          <%= f.button :submit, value: 'Add to booking', class: 'btn btn-primary' %>
-          <% end %>
+          <%= link_to 'Add to Booking', mobfriend_your_events_path(mobfriend), class: 'btn btn-info' %>
         </div>
       </div>
     </div>

--- a/app/views/mobfriends/new.html.erb
+++ b/app/views/mobfriends/new.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/navbar' %>
 <div class="page-header">
   <h1>Create Profile</h1>
 </div>

--- a/app/views/mobfriends/show.html.erb
+++ b/app/views/mobfriends/show.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/navbar' %>
 <div class="header text-center my-5">
   <h1><%= @mobfriend.first_name.capitalize %> <%= @mobfriend.last_name.capitalize %></h1>
 </div>
@@ -24,8 +23,6 @@
   </div>
 <div class="buttons-container">
   <%= link_to 'Back', mobfriends_path, class: 'btn btn-info' %>
-  <%= simple_form_for [@mobfriend, @job] do |f| %>
-  <%= f.button :submit, value: 'Add to booking', class: 'btn btn-primary' %>
-  <% end %>
+  <%= link_to 'Add to Booking', mobfriend_your_events_path(@mobfriend), class: 'btn btn-info' %>
 </div>
 </div>

--- a/app/views/pages/_dashboard_add_jobs.html.erb
+++ b/app/views/pages/_dashboard_add_jobs.html.erb
@@ -1,0 +1,6 @@
+<div class="section">
+  <div class="subheader">
+    <p>You're a Mobfriend without any gigs</p>
+  </div>
+  <h3>Join a crowd!</h3>
+</div>

--- a/app/views/pages/_dashboard_buttons_bar.html.erb
+++ b/app/views/pages/_dashboard_buttons_bar.html.erb
@@ -1,0 +1,5 @@
+<div class="buttons-bar d-flex justify-content-center my-3">
+  <%= link_to 'Create Event', new_event_path, class: 'btn btn-light' %>
+  <%= link_to 'Mobfriend Profile', new_mobfriend_path, class: 'btn btn-light' %>
+  <%= link_to 'Join a Gig', '#', class: 'btn btn-light' %>
+</div>

--- a/app/views/pages/_dashboard_confirmed_events.html.erb
+++ b/app/views/pages/_dashboard_confirmed_events.html.erb
@@ -1,0 +1,23 @@
+<div class="section">
+  <div class="subheader">
+    <p>Events confirmed</p>
+  </div>
+  <div class="container">
+    <div class="row">
+      <% @confirmed_events.each do |event| %>
+        <div class="col-lg-4">
+          <%= image_tag("https://source.unsplash.com/600x400/?#{event.event_type}", width: '100%') %>
+        </div>
+        <div class="col-lg-8 my-5">
+          <ul>
+            <li>Type: <%= event.event_type %></li>
+            <li>Time: <%= "#{event.datetime.hour}:#{event.datetime.min}" %></li>
+            <li>Location: <%= event.event_location %></li>
+            <li>Status: Confirmed</li>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/_dashboard_create_event_or_job.html.erb
+++ b/app/views/pages/_dashboard_create_event_or_job.html.erb
@@ -1,0 +1,6 @@
+<div class="section">
+  <div class="subheader">
+    <p>Pick something to do</p>
+  </div>
+  <h3>Create an Event or Become a Mobfriend!</h3>
+</div>

--- a/app/views/pages/_dashboard_pending_events.html.erb
+++ b/app/views/pages/_dashboard_pending_events.html.erb
@@ -1,0 +1,27 @@
+<div class="section">
+  <div class="subheader">
+    <p>Events pending</p>
+  </div>
+  <div class="container">
+    <div class="row">
+      <% @pending_events.each do |event| %>
+        <div class="col-lg-4">
+          <%= image_tag("https://source.unsplash.com/600x400/?#{event.event_type}", width: '100%') %>
+        </div>
+        <div class="col-lg-8 my-5">
+          <ul>
+            <li>Type: <%= event.event_type %></li>
+            <li>Time: <%= "#{event.datetime.hour}:#{event.datetime.min}" %></li>
+            <li>Location: <%= event.event_location %></li>
+            <li>Status: Unconfirmed</li>
+            <%= simple_form_for event do |f| %>
+            <%= f.hidden_field :confirmed, value: true %>
+            <%= f.button :submit, class: 'btn btn-primary my-5' %>
+            <% end %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/_dashboard_pending_jobs.html.erb
+++ b/app/views/pages/_dashboard_pending_jobs.html.erb
@@ -1,0 +1,31 @@
+<div class="section">
+  <div class="subheader">
+    <p>Jobs pending</p>
+  </div>
+  <div class="container">
+    <div class="row">
+      <% @jobs.each.each do |job| %>
+        <div class="col-lg-4">
+          <%= image_tag("https://source.unsplash.com/600x400/?#{job.event.event_type}", width: '100%') %>
+        </div>
+        <div class="col-lg-8 my-5">
+          <ul>
+            <li>Type: <%= job.event.event_type %></li>
+            <li>Time: <%= "#{job.event.datetime.hour}:#{job.event.datetime.min}" %></li>
+            <li>Location: <%= job.event.event_location %></li>
+            <% if job.accepted %>
+              <li>Status: You have accepted this job</li>
+            <% else %>
+              <li>Status: You have not accepted this job</li>
+              <%= simple_form_for job do |f| %>
+              <%= f.hidden_field :accepted, value: true %>
+              <%= f.button :submit, class: 'btn btn-primary my-5' %>
+              <% end %>
+            <% end %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,0 +1,21 @@
+<div class="header">
+  <h1>Welcome to your dashboard</h1>
+</div>
+<%= render 'dashboard_buttons_bar' %>
+<% if @events.present? %>
+  <% if @pending_events.present? %>
+    <%= render 'dashboard_pending_events' %>
+  <% else %>
+    <%= render 'dashboard_confirmed_events' %>
+  <% end %>
+<% end %>
+<% if @mobfriend.present? %>
+  <% if @jobs.present? %>
+    <%= render 'dashboard_pending_jobs' %>
+  <% else %>
+    <%= render 'dashboard_add_jobs' %>
+  <% end %>
+<% end %>
+<% if @events.nil? && @mobfriend.nil?%>
+  <%= render 'dashboard_create_event_or_job' %>
+<% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,16 +1,10 @@
-<%= render 'shared/navbar' %>
-<!-- <h1>Pages#home</h1>
-<p>Find me in app/views/pages/home.html.erb</p>
-<h1>Mobfriends my mannnn</h1>
-<p>This is a beautiful landing page</p>
- -->
- <div class="jumbotron jumbotron-fluid mb-0">
-  <div class="display: flex">
-    <div class="landing-page-callout ml-5">
-      <h1 class="display-3">Want some friends?</h1>
-      <h5 class="ml-3">Rent one today! Starts from $7/hour.</h5>
-      <%= link_to 'Sign Up', new_user_registration_path, :class => "btn btn-light ml-3"%>
-    </div>
+<div class="jumbotron jumbotron-fluid mb-0">
+<div class="display: flex">
+  <div class="landing-page-callout ml-5">
+    <h1 class="display-3">Want some friends?</h1>
+    <h5 class="ml-3">Rent one today! Starts from $7/hour.</h5>
+    <%= link_to 'Sign Up', new_user_registration_path, :class => "btn btn-light ml-3"%>
   </div>
+</div>
 </div>
 <%= render 'shared/footer' %>

--- a/app/views/pages/your_events.html.erb
+++ b/app/views/pages/your_events.html.erb
@@ -1,0 +1,23 @@
+<div class="header">
+  <h1>Add Mobfriend to Your Event</h1>
+  <div class="container">
+    <div class="row">
+      <% @pending_events.each do |event| %>
+        <div class="col-lg-4">
+          <%= image_tag("https://source.unsplash.com/600x400/?#{event.event_type}", width: '100%') %>
+        </div>
+        <div class="col-lg-8 my-5">
+          <ul>
+            <li>Type: <%= event.event_type %></li>
+            <li>Time: <%= "#{event.datetime.hour}:#{event.datetime.min}" %></li>
+            <li>Location: <%= event.event_location %></li>
+          </ul>
+          <%= simple_form_for [@mobfriend, @job] do |f| %>
+          <%= f.hidden_field :event, value: event.id %>
+          <%= f.button :submit, value: 'Add to booking', class: 'btn btn-primary' %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -27,7 +27,7 @@
         <li class="nav-item dropdown">
           <%= image_tag "koala.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <%= link_to "Action", "#", class: "dropdown-item" %>
+            <%= link_to "Dashboard", dashboard_path, class: "dropdown-item" %>
             <%= link_to "Another action", "#", class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,15 @@ Rails.application.routes.draw do
   # get 'events/update'
   # get 'events/destroy'
   devise_for :users
+
+  get 'dashboard', to: 'pages#dashboard', as: 'dashboard'
   root to: 'pages#home'
 
   resources :jobs, only: :destroy
 
   resources :mobfriends do
     resources :jobs, only: :create
+    get 'your-events', to: 'pages#your_events', as: 'your_events'
   end
 
 


### PR DESCRIPTION
User now adds Mobfriend to job from either mobfriends#index or mobfriends#show page via your-events page.
// Job creation process
This page displays all pending events for the current_user (excludes confirmed events).
User selects event to add Mobfriend to from your_event page.
//

Deleted empty event pages